### PR TITLE
fixed missing flag for publishing port 6006 in docker run step

### DIFF
--- a/setup/install-cloud.md
+++ b/setup/install-cloud.md
@@ -64,7 +64,7 @@ gcloud compute firewall-rules create workshop --allow tcp:8888,tcp:6006
 In the SSH browser window that's connected to the GCE instance, run this command to download and run the container:
 
 ```shell
-$ docker run -it -p 8888:8888 p 6006:6006 tensorflow/tensorflow bash
+$ docker run -it -p 8888:8888 -p 6006:6006 tensorflow/tensorflow bash
 ```
 
 When this command completes, the terminal in your SSH browser window will be connected to the running container.


### PR DESCRIPTION
`docker run -it -p 8888:8888 p 6006:6006 tensorflow/tensorflow bash` searches for docker image `p`.  I updated the p to -p so that the container publishes port 6006 as desired.