### PR TITLE
Add high-level API examples.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,6 @@ ENV/
 
 .DS_Store
 
+# Ignore the "graphs" output directory
+examples/graphs/
+

--- a/examples/02_logistic_regression_mnist.ipynb
+++ b/examples/02_logistic_regression_mnist.ipynb
@@ -57,9 +57,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Import the MNIST dataset. \n",
@@ -181,9 +179,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Evaluate the trained model\n",

--- a/examples/05_deep_neural_network_mnist_layers.ipynb
+++ b/examples/05_deep_neural_network_mnist_layers.ipynb
@@ -1,0 +1,273 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true
+   },
+   "source": [
+    "### MNist DNN with Layers\n",
+    "\n",
+    "In this example, we use a deep neural network to classify the MNIST dataset. This code is very similar to the 3rd example (deep_neural_network_mnist), however instead of defining all the details with the low-level TensorFlow API, we instead use the TensorFlow layers API to simplify the construction of the model.\n",
+    "\n",
+    "Important takeaway: the code to train the model is identical to the previous notebook, despite the alternate APIs to describe the model.\n",
+    "\n",
+    "This model achieves the same accuracy as the previous one (>97%)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "from __future__ import absolute_import\n",
+    "from __future__ import division\n",
+    "from __future__ import print_function\n",
+    "\n",
+    "import math\n",
+    "import os\n",
+    "\n",
+    "import tensorflow as tf\n",
+    "from tensorflow.examples.tutorials.mnist import input_data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "tf.reset_default_graph()\n",
+    "sess = tf.Session()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# tip: if you run into problems with TensorBoard\n",
+    "# clear the contents of this directory, re-run this script\n",
+    "# then restart TensorBoard to see the result\n",
+    "LOGDIR = './graphs' "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mnist = input_data.read_data_sets('/tmp/data', one_hot=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# number of neurons in each hidden layer\n",
+    "HIDDEN1_SIZE = 500\n",
+    "HIDDEN2_SIZE = 250\n",
+    "\n",
+    "NUM_CLASSES = 10\n",
+    "NUM_PIXELS = 28 * 28\n",
+    "\n",
+    "# experiment with the nubmer of training steps to \n",
+    "# see the effect\n",
+    "TRAIN_STEPS = 2000\n",
+    "BATCH_SIZE = 100\n",
+    "\n",
+    "# we're using a different learning rate than the previous\n",
+    "# notebook, and a new optimizer\n",
+    "LEARNING_RATE = 0.001"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# Define inputs\n",
+    "with tf.name_scope('input'):\n",
+    "    images = tf.placeholder(tf.float32, [None, NUM_PIXELS], name=\"pixels\")\n",
+    "    labels = tf.placeholder(tf.float32, [None, NUM_CLASSES], name=\"labels\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Up until this point, everything is effectively identical to authoring the deep neural networks with the low-level APIs. But from here on, we diverge."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# Define the model\n",
+    "\n",
+    "# First we'll create 2 fully-connected layers, with ReLU activations.\n",
+    "fc1 = tf.layers.dense(images, HIDDEN1_SIZE, activation=tf.nn.relu, name=\"fc1\")\n",
+    "fc2 = tf.layers.dense(fc1, HIDDEN2_SIZE, activation=tf.nn.relu, name=\"fc2\")\n",
+    "\n",
+    "# Next, we'll apply Dropout to the second layer\n",
+    "# This can help prevent overfitting, and I've added it here\n",
+    "# for illustration. You can comment this out, if you like.\n",
+    "dropped = tf.nn.dropout(fc2, keep_prob=0.9, name=\"dropout1\")\n",
+    "\n",
+    "# Finally, we'll calculate logists. This will be\n",
+    "# the input to our Softmax function. Notice we \n",
+    "# don't apply an activation at this layer.\n",
+    "# If you've commented out the dropout layer,\n",
+    "# switch the input here to 'fc2'.\n",
+    "y = tf.layers.dense(dropped, NUM_CLASSES, name=\"output\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# Define loss and an optimizer\n",
+    "with tf.name_scope(\"loss\"):\n",
+    "    loss = tf.reduce_mean(tf.nn.softmax_cross_entropy_with_logits(logits=y, labels=labels))\n",
+    "    tf.summary.scalar('loss', loss)\n",
+    "\n",
+    "with tf.name_scope(\"optimizer\"):\n",
+    "    # Whereas in the previous notebook we used a vanilla GradientDescentOptimizer\n",
+    "    # here, we're using Adam. This is a single line of code change, and more\n",
+    "    # importantly, TensorFlow will still automatically analyze our graph\n",
+    "    # and determine how to adjust the variables to decrease the loss.\n",
+    "    train = tf.train.AdamOptimizer(LEARNING_RATE).minimize(loss)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# Define evaluation\n",
+    "with tf.name_scope(\"evaluation\"):\n",
+    "    # these there lines are identical to the previous notebook.\n",
+    "    correct_prediction = tf.equal(tf.argmax(y, 1), tf.argmax(labels, 1))\n",
+    "    accuracy = tf.reduce_mean(tf.cast(correct_prediction, tf.float32))\n",
+    "    tf.summary.scalar('accuracy', accuracy)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# Set up logging.\n",
+    "# We'll use a second FileWriter to summarize accuracy on\n",
+    "# the test set. This will let us display it nicely in TensorBoard.\n",
+    "train_writer = tf.summary.FileWriter(os.path.join(LOGDIR, \"train\"))\n",
+    "train_writer.add_graph(sess.graph)\n",
+    "test_writer = tf.summary.FileWriter(os.path.join(LOGDIR, \"test\"))\n",
+    "summary_op = tf.summary.merge_all()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "sess.run(tf.global_variables_initializer())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for step in range(TRAIN_STEPS):\n",
+    "    batch_xs, batch_ys = mnist.train.next_batch(BATCH_SIZE)\n",
+    "    summary_result, _ = sess.run([summary_op, train], \n",
+    "                                    feed_dict={images: batch_xs, labels: batch_ys})\n",
+    "\n",
+    "    train_writer.add_summary(summary_result, step)\n",
+    "    train_writer.add_run_metadata(tf.RunMetadata(), 'step%03d' % step)\n",
+    "    \n",
+    "    # calculate accuracy on the test set, every 100 steps.\n",
+    "    # we're using the entire test set here, so this will be a bit slow\n",
+    "    if step % 100 == 0:\n",
+    "        summary_result, acc = sess.run([summary_op, accuracy], \n",
+    "                                       feed_dict={images: mnist.test.images, \n",
+    "                                                  labels: mnist.test.labels})\n",
+    "        test_writer.add_summary(summary_result, step)\n",
+    "        test_writer.add_run_metadata(tf.RunMetadata(), 'step%03d' % step)\n",
+    "        print (\"test accuracy: %f at step %d\" % (acc, step))\n",
+    "\n",
+    "\n",
+    "print(\"Accuracy %f\" % sess.run(accuracy, \n",
+    "                               feed_dict={images: mnist.test.images,\n",
+    "                                          labels: mnist.test.labels}))\n",
+    "train_writer.close()\n",
+    "test_writer.close()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/examples/06_deep_neural_network_mnist_estimators.ipynb
+++ b/examples/06_deep_neural_network_mnist_estimators.ipynb
@@ -1,0 +1,194 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### MNIST DNN with Estimators & Layers\n",
+    "\n",
+    "In this example, we will use a deep neural network to classify the MNIST dataset. This code is very similar to the 5th example (deep_neural_network_mnist_layers), however instead of manually managing the session and TensorBoard, we let Estimators handle this for us."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "from __future__ import absolute_import\n",
+    "from __future__ import division\n",
+    "from __future__ import print_function\n",
+    "\n",
+    "import math\n",
+    "import os\n",
+    "\n",
+    "import tensorflow as tf\n",
+    "from tensorflow.examples.tutorials.mnist import input_data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "When using Estimators, we do not manage the TensorFlow session directly. Instead, we skip straight to defining our hyperparameters."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# number of neurons in each hidden layer\n",
+    "HIDDEN1_SIZE = 500\n",
+    "HIDDEN2_SIZE = 250\n",
+    "\n",
+    "NUM_CLASSES = 10  # 10 digits 0-9\n",
+    "NUM_PIXELS = 28 * 28  # dataset size.\n",
+    "\n",
+    "# experiment with the nubmer of training steps to \n",
+    "# see the effect\n",
+    "TRAIN_STEPS = 2000\n",
+    "BATCH_SIZE = 100\n",
+    "\n",
+    "# we're using a different learning rate than the previous\n",
+    "# notebook, and a new optimizer\n",
+    "LEARNING_RATE = 0.001"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# Define our model\n",
+    "def model_fn(features, labels, mode):\n",
+    "    \n",
+    "    # First we'll create 2 fully-connected layers, with ReLU activations.\n",
+    "    fc1 = tf.layers.dense(features, HIDDEN1_SIZE, activation=tf.nn.relu, name=\"fc1\")\n",
+    "    fc2 = tf.layers.dense(fc1, HIDDEN2_SIZE, activation=tf.nn.relu, name=\"fc2\")\n",
+    "\n",
+    "    # Next, we'll apply Dropout to the second layer\n",
+    "    # This can help prevent overfitting, and I've added it here\n",
+    "    # for illustration. You can comment this out, if you like.\n",
+    "    dropped = tf.nn.dropout(fc2, keep_prob=0.9, name=\"dropout1\")\n",
+    "\n",
+    "    # Finally, we'll calculate logists. This will be\n",
+    "    # the input to our Softmax function. Notice we \n",
+    "    # don't apply an activation at this layer.\n",
+    "    # If you've commented out the dropout layer,\n",
+    "    # switch the input here to 'fc2'.\n",
+    "    y = tf.layers.dense(dropped, NUM_CLASSES, name=\"output\")\n",
+    "    \n",
+    "    # Compute the loss\n",
+    "    loss = tf.losses.softmax_cross_entropy(\n",
+    "        onehot_labels=labels, logits=y)\n",
+    "    \n",
+    "    tf.summary.scalar('loss', loss)\n",
+    "    \n",
+    "    learning_rate = LEARNING_RATE\n",
+    "    # Alternate learning rate calculation\n",
+    "    #learning_rate = tf.train.exponential_decay(\n",
+    "    #  LEARNING_RATE, tf.train.get_global_step(), 100000, 0.96)\n",
+    "    \n",
+    "    # Define the optimizer\n",
+    "    optimizer = tf.train.GradientDescentOptimizer(learning_rate=learning_rate)\n",
+    "    train_op = optimizer.minimize(loss, global_step=tf.train.get_global_step())\n",
+    "    \n",
+    "    # Return an estimator spec that encapsulates your model.\n",
+    "    return tf.estimator.EstimatorSpec(\n",
+    "        mode=mode, loss=loss, train_op=train_op)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# Define our data input function\n",
+    "def input_fn():\n",
+    "    # Use the new datasets API!\n",
+    "    mnist = input_data.read_data_sets('/tmp/data', one_hot=True)\n",
+    "    images = mnist.train.images\n",
+    "    labels = mnist.train.labels\n",
+    "    assert(images.shape[0] == labels.shape[0])  # Same number of examples\n",
+    "    \n",
+    "    image_dataset = tf.contrib.data.Dataset.from_tensor_slices(images)\n",
+    "    label_dataset = tf.contrib.data.Dataset.from_tensor_slices(labels)\n",
+    "    dataset = tf.contrib.data.Dataset.zip((image_dataset, label_dataset))\n",
+    "    dataset = dataset.repeat()  # repeat indefinitely\n",
+    "    dataset = dataset.shuffle(buffer_size=labels.shape[0])\n",
+    "    dataset = dataset.batch(BATCH_SIZE)\n",
+    "    \n",
+    "    return dataset.make_one_shot_iterator().get_next()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define the run configuration.\n",
+    "estimator = tf.estimator.Estimator(model_fn=model_fn)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Train the estimator using our input function\n",
+    "estimator.train(input_fn=input_fn, steps=TRAIN_STEPS)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Exercise for the reader: support the other modes for estimators. (i.e. test and predict.)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Code can be simplified when using TensorFlow's high-level APIs. This commit
adds 2 additional examples: (1) using TensorFlow layers to create our fully-
connected layers in our MNIST network, and (2) wrap our model in an Estimator
which then drives the training of our model. Additionally, in the estimator
code, I've converted to using the new Datasets API for higher-performance
input pipelines.

This code is first presented at the Deep Learning Summer School in Montreal
2017.